### PR TITLE
Create implementation of Observer-Pattern

### DIFF
--- a/src/sandbox.catcoder.sln
+++ b/src/sandbox.catcoder.sln
@@ -10,6 +10,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "toolbox.DiscriminatedUnions
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "toolbox.Duplicatables", "toolbox.Duplicatables\toolbox.Duplicatables.csproj", "{A2B94B21-AEDD-486A-A331-9511749099EC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "toolbox.Observables", "toolbox.Observables\toolbox.Observables.csproj", "{5ED4B393-311F-47BA-94D7-38D4F0E96F63}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "toolbox.Observables.Tests", "toolbox.Observables.Tests\toolbox.Observables.Tests.csproj", "{6E133588-2832-40FD-833A-E4357B42AF12}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,8 +32,17 @@ Global
 		{A2B94B21-AEDD-486A-A331-9511749099EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A2B94B21-AEDD-486A-A331-9511749099EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A2B94B21-AEDD-486A-A331-9511749099EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5ED4B393-311F-47BA-94D7-38D4F0E96F63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ED4B393-311F-47BA-94D7-38D4F0E96F63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ED4B393-311F-47BA-94D7-38D4F0E96F63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5ED4B393-311F-47BA-94D7-38D4F0E96F63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E133588-2832-40FD-833A-E4357B42AF12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E133588-2832-40FD-833A-E4357B42AF12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E133588-2832-40FD-833A-E4357B42AF12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E133588-2832-40FD-833A-E4357B42AF12}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EF13D394-B49B-43CB-ACC2-40F6CF1A1752} = {D31F38CC-4870-4F29-B756-5808BCBFEF0B}
+		{6E133588-2832-40FD-833A-E4357B42AF12} = {D31F38CC-4870-4F29-B756-5808BCBFEF0B}
 	EndGlobalSection
 EndGlobal

--- a/src/toolbox.Observables.Tests/PublisherTests.cs
+++ b/src/toolbox.Observables.Tests/PublisherTests.cs
@@ -1,0 +1,51 @@
+using Moq;
+using Xunit;
+
+
+namespace toolbox.Observables.Tests; 
+
+public class PublisherTests {
+    
+    // -- test setup
+    private readonly Publisher <string> testObject = new();
+    
+    
+    // -- test cases
+    [Fact]
+    public void Subscribe_ExpectUniqueEntries() {
+
+        var mockedSubscribers = Enumerable.Range(0, 2)
+            .Select(i => new Mock <ISubscriber <string>>())
+            .ToList();
+        
+        mockedSubscribers
+            .ForEach(mocked => this.testObject.Subscribe(mocked.Object));
+        
+        this.testObject.NotifySubscribers("Hello, World!");
+        mockedSubscribers
+            .ForEach(mocked => mocked.Verify(
+                sub => sub.Notify(It.IsAny<string>()), Times.Once()));
+    }
+
+    [Fact]
+    public void Subscribe_ExpectFailureDueCommonEntries() {
+        
+        var mockedSubscribers = Enumerable.Range(0, 2)
+            .Select(i => new Mock <ISubscriber <string>>())
+            .ToList();
+        
+        mockedSubscribers
+            .ForEach(mocked => this.testObject.Subscribe(mocked.Object));
+        // break integrity of subscriber list
+        this.testObject.Subscribe(mockedSubscribers.First().Object);
+        
+        this.testObject.NotifySubscribers("Hello, World!");
+        mockedSubscribers
+            .ForEach(mocked => mocked.Verify(
+                sub => sub.Notify(It.IsAny<string>()), Times.Exactly(1)));
+    }
+    
+    
+    
+    
+}

--- a/src/toolbox.Observables.Tests/SubscriberTests.cs
+++ b/src/toolbox.Observables.Tests/SubscriberTests.cs
@@ -1,0 +1,24 @@
+using Moq;
+using Xunit;
+
+
+namespace toolbox.Observables.Tests; 
+
+public class SubscriberTests {
+
+    // -- test setup
+    private ISubscriber <string> testObject;
+    
+    // -- test cases
+    [Fact]
+    public void Notify_ExpectCallbackAfterNotification() {
+
+        bool callbackWasCalled = false;
+
+        this.testObject = new Subscriber <string>(context => callbackWasCalled = true);
+        this.testObject.Notify("Hello, World");
+        
+        Assert.True(callbackWasCalled);
+        
+    }
+}

--- a/src/toolbox.Observables.Tests/toolbox.Observables.Tests.csproj
+++ b/src/toolbox.Observables.Tests/toolbox.Observables.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\toolbox.Observables\toolbox.Observables.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/toolbox.Observables/IPublisher.cs
+++ b/src/toolbox.Observables/IPublisher.cs
@@ -1,0 +1,8 @@
+namespace toolbox.Observables; 
+
+public interface IPublisher <TContext> {
+
+    public void Subscribe (ISubscriber <TContext> subscriber);
+    public void Unsubscribe (ISubscriber <TContext> subscriber);
+    public void NotifySubscribers (TContext context);
+}

--- a/src/toolbox.Observables/ISubscriber.cs
+++ b/src/toolbox.Observables/ISubscriber.cs
@@ -1,0 +1,6 @@
+namespace toolbox.Observables; 
+
+public interface ISubscriber <TContext> {
+
+    public void Notify (TContext context);
+}

--- a/src/toolbox.Observables/Publisher.cs
+++ b/src/toolbox.Observables/Publisher.cs
@@ -1,0 +1,31 @@
+namespace toolbox.Observables; 
+
+public class Publisher <TContext> : IPublisher <TContext> {
+
+    private readonly HashSet <ISubscriber <TContext>> subscribers;
+    private TContext? mainState;
+    
+    // -- constructors
+    public Publisher()
+        => this.subscribers = new();
+
+    public Publisher (ISubscriber <TContext> subscriber)
+        => this.subscribers = new() {subscriber};
+
+    public Publisher (ICollection <ISubscriber <TContext>> subscribers)
+        => this.subscribers = new(subscribers);
+    
+    // -- implemented interfaces 
+    public void Subscribe (ISubscriber <TContext> subscriber)
+        => this.subscribers.Add(subscriber);
+
+    public void Unsubscribe (ISubscriber <TContext> subscriber)
+        => this.subscribers.Remove(subscriber);
+
+    public void NotifySubscribers (TContext context) {
+        this.mainState = context;
+        this.subscribers
+            .ToList()
+            .ForEach(subscriber => subscriber.Notify(this.mainState));
+    }
+}

--- a/src/toolbox.Observables/Subscriber.cs
+++ b/src/toolbox.Observables/Subscriber.cs
@@ -1,0 +1,14 @@
+namespace toolbox.Observables; 
+
+public class Subscriber <TContext> : ISubscriber <TContext> {
+    
+    private Action <TContext> callback;
+    
+    // -- constructors
+    public Subscriber (Action <TContext> callback)
+        => this.callback = callback;
+    
+    // -- implemented interfaces 
+    public void Notify (TContext context)
+        => this.callback(context);
+}

--- a/src/toolbox.Observables/toolbox.Observables.csproj
+++ b/src/toolbox.Observables/toolbox.Observables.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+
+
+</Project>


### PR DESCRIPTION
### ✅ Summary
Added a modular implementation of the Observer Pattern, consisting of generic interfaces and concrete publisher/subscriber classes to enable reactive communication between components.

### 🛠️ Details
- Introduced ``IPublisher<TContext>`` and ``ISubscriber<TContext>`` interfaces
- Implemented ``Subscribe``, ``Unsubscribe``, and ``NotifySubscribers`` methods
- Ensured subscribers are notified exactly once per update
- Added constructors for initializing publishers with one or multiple subscribers
- Code adheres to ``SOLID`` principles and supports unit testing via Moq

### 📝 Notes
- ``HashSet`` ensures uniqueness of subscriber registrations
- Internal state (mainState) can be extended for advanced features (e.g. state caching)
- Ready for integration into other projects
- Additional unit tests can be added to test concurrency or edge-case behavior